### PR TITLE
Cap occupancy calculation at 100% maximum

### DIFF
--- a/src/components/TransposedCalculatedMetricsTable.tsx
+++ b/src/components/TransposedCalculatedMetricsTable.tsx
@@ -150,7 +150,7 @@ export function TransposedCalculatedMetricsTable({
 
       // Excel SMORT Utilisation(BA7,BD7*2,BE7) - Occupancy calculation
       const occupancy = rosteredAgents > 0 ?
-        (trafficIntensityDoubled / rosteredAgents) * 100 : 0;
+        Math.min(100, (trafficIntensityDoubled / rosteredAgents) * 100) : 0;
       // Excel SMORT Influx: =IFERROR((BA7/BB7),0) = Effective Volume / Required Agents
       const influx = requiredAgents > 0 ? effectiveVolume / requiredAgents : 0;
       const agentDistributionRatio = calculateAgentDistributionRatio(rosteredAgents, totalAgents);


### PR DESCRIPTION
## Purpose
Fix occupancy calculation in TransposedCalculatedMetricsTable to prevent values from exceeding 100%, ensuring accurate percentage representation of agent utilization.

## Code changes
- Modified occupancy calculation in `TransposedCalculatedMetricsTable.tsx` to use `Math.min(100, ...)` wrapper
- Ensures occupancy percentage is capped at 100% maximum while preserving the original calculation logic
- Applied to line 153 where `(trafficIntensityDoubled / rosteredAgents) * 100` is computed

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/5ad4007ed4c94097ae9606371f3ff20c/orbit-space)

👀 [Preview Link](https://5ad4007ed4c94097ae9606371f3ff20c-orbit-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5ad4007ed4c94097ae9606371f3ff20c</projectId>-->
<!--<branchName>orbit-space</branchName>-->